### PR TITLE
New: Push WM update after setting relations or properties

### DIFF
--- a/skiros2_std_skills/src/skiros2_std_skills/utility_primitives.py
+++ b/skiros2_std_skills/src/skiros2_std_skills/utility_primitives.py
@@ -76,6 +76,8 @@ class wm_set_relation(PrimitiveBase):
                 src.removeRelation(rel)
         self.params["Src"].value = src
         self.params["Dst"].value = dst
+        self._wmi.update_element(src)
+        self._wmi.update_element(dst)
         return self.success("{} {}-{}-{}".format("Set" if self.params["RelationState"].value else "Unset", src.id, relation, dst.id))
 
 #################################################################################
@@ -104,6 +106,7 @@ class wm_set_properties(PrimitiveBase):
         for k, v in props.items():
             src.setProperty(k, v)
         self.params["Src"].value = src
+        self._wmi.update_element_properties(src)
         return self.success("Setted properties to {}. {}".format(src.id, props))
 
 #################################################################################


### PR DESCRIPTION
Makes sure that changes are synchronized.

I might be off on this, but my understanding is that this needs to be done to ensure that changes from the BB are reflected in the WM.